### PR TITLE
Use extract-zip-fork to fix unzip issues

### DIFF
--- a/lib/transform/aar-transformer.js
+++ b/lib/transform/aar-transformer.js
@@ -3,7 +3,7 @@
 
 var async = require('async');
 var DOMParser = require('xmldom').DOMParser;
-var extract = require('extract-zip');
+var extract = require('extract-zip-fork');
 var find = require('findit2');
 var fs = require('fs-extra');
 var path = require('path');

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "async": "^2.1.4",
     "deepmerge": "^1.3.2",
-    "extract-zip": "^1.6.0",
+    "extract-zip-fork": "^1.5.1",
     "findit2": "^2.2.3",
     "fs-extra": "^1.0.0",
     "xmldom": "^0.1.27"


### PR DESCRIPTION
The extract-zip module sometimes has an issue properly detecting zip file entries as directories. This commit switches to a forked version with a fix for that issue.