### PR TITLE
[TIMOB-25353] Validate classes.jar path

### DIFF
--- a/lib/transform/aar-transformer.js
+++ b/lib/transform/aar-transformer.js
@@ -141,11 +141,13 @@ class AarTransformer {
    */
   registerAndCopyLibraries(next) {
     var mainJarPathAndFilename = path.join(this.outputPath, 'classes.jar');
-    this.logger.trace('Adding main JAR to list: %s', mainJarPathAndFilename);
-    this.result.addJar(mainJarPathAndFilename);
-    if (this.libraryDestinationPath !== null) {
-      var dest = path.join(this.libraryDestinationPath, this.aarBasename + '.jar');
-      fs.copySync(mainJarPathAndFilename, dest);
+    if (fs.existsSync(mainJarPathAndFilename)) {
+      this.logger.trace('Adding main JAR to list: %s', mainJarPathAndFilename);
+      this.result.addJar(mainJarPathAndFilename);
+      if (this.libraryDestinationPath !== null) {
+        var dest = path.join(this.libraryDestinationPath, this.aarBasename + '.jar');
+        fs.copySync(mainJarPathAndFilename, dest);
+      }
     }
 
     var libraryPath = path.join(this.outputPath, 'libs');


### PR DESCRIPTION
- Only add `classes.jar` if it exists
- Part of fixes for https://github.com/appcelerator/titanium_mobile/pull/9481

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-25353)