### PR TITLE
Add exception for debug regex vulnerabiliy

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,0 +1,4 @@
+{
+  "exceptions": ["https://nodesecurity.io/advisories/534"]
+}
+


### PR DESCRIPTION
Caused by extract-zip-fork but unimportant for this project. Can be removed once there finally is an updated extract-zip available.